### PR TITLE
Fix/indicator default color

### DIFF
--- a/dist/stylesheets/kit/components/_indicator.trend.scss
+++ b/dist/stylesheets/kit/components/_indicator.trend.scss
@@ -9,12 +9,12 @@
 // =============================================================================
 // Trend indicator
 // =============================================================================
-.ind-trend {
+body.theme {
     @include defineColor(--indicator-trend-color, inherit);
-    @include defineColor(--indicator-trend--is-decrease-color, var(--danger-accent-50-color));
-    @include defineColor(--indicator-trend--is-increase-color, var(--success-accent-50-color));
+    @include defineColor(--indicator-trend--is-decrease-color, var(--vis-red-named-color));
+    @include defineColor(--indicator-trend--is-increase-color, var(--vis-green-named-color));
     @include defineColor(--indicator-trend--is-monochrome-color, inherit);
-    @include defineColor(--indicator-trend--is-steady-color, var(--notice-accent-50-color));
+    @include defineColor(--indicator-trend--is-steady-color, var(--vis-blue-named-color));
 }
 
 .ind-trend {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-kit",
-  "version": "3.7.5",
+  "version": "3.7.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui-kit",
-  "version": "3.7.5",
+  "version": "3.7.6",
   "title": "UI Kit",
   "description": "datasapiens sass toolkit and components library",
   "company": {

--- a/src/sass/components/_indicator.trend.scss
+++ b/src/sass/components/_indicator.trend.scss
@@ -9,12 +9,12 @@
 // =============================================================================
 // Trend indicator
 // =============================================================================
-.ind-trend {
+body.theme {
     @include defineColor(--indicator-trend-color, inherit);
-    @include defineColor(--indicator-trend--is-decrease-color, var(--danger-accent-50-color));
-    @include defineColor(--indicator-trend--is-increase-color, var(--success-accent-50-color));
+    @include defineColor(--indicator-trend--is-decrease-color, var(--vis-red-named-color));
+    @include defineColor(--indicator-trend--is-increase-color, var(--vis-green-named-color));
     @include defineColor(--indicator-trend--is-monochrome-color, inherit);
-    @include defineColor(--indicator-trend--is-steady-color, var(--notice-accent-50-color));
+    @include defineColor(--indicator-trend--is-steady-color, var(--vis-blue-named-color));
 }
 
 .ind-trend {


### PR DESCRIPTION
Fix default colors for indicator trend and move color variables to body, because they need to be available in other components.